### PR TITLE
Make several tweaks to get the project to compile and run on windows (Visual Studio 15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ cd build
 cmake -G "Visual Studio 12" ../
 # open the generated SLN file (or cbp file if using CodeBlocks) and build!
 ```
+- Make sure in the SDL2 include directory, the header files are properly nested under an SDL2 sub directory. The directory structure should look something like : `C:\Program Files\SDL2\include\SDL2\`.
 - Copy the DLLs in /lib/_bin/ to /build/Debug/ and /build/Release/
 - In Visual Studio, set the Startup project to CGFX5
 - Move the res folder into the build folder

--- a/src/core/common.hpp
+++ b/src/core/common.hpp
@@ -70,7 +70,11 @@ typedef uintptr_t uintptr;
 	#define assertCheck (void)
 #endif
 
-#define FORCEINLINE inline __attribute__ ((always_inline))
+#ifdef __GNUC__
+	#define FORCEINLINE inline __attribute__ ((always_inline))
+#else
+	#define FORCEINLINE inline
+#endif
 
 #if __cplusplus < 201103L
 	#define nullptr NULL

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,7 +128,12 @@ static int runApp(Application* app)
 	return 0;
 }
 
+
+#ifdef __GNUC__
 int main(int argc, char** argv)
+#else
+int wmain(int argc, char** argv)
+#endif
 {
 	Application* app = Application::create();
 	int result = runApp(app);

--- a/src/platform/generic/genericMath.cpp
+++ b/src/platform/generic/genericMath.cpp
@@ -1,12 +1,13 @@
 #include "genericMath.hpp"
 
-CONSTEXPR const float GenericMath::PI;
-CONSTEXPR const float GenericMath::TWO_PI;
-CONSTEXPR const float GenericMath::HALF_PI;
-CONSTEXPR const float GenericMath::R_PI;
-CONSTEXPR const float GenericMath::R_TWO_PI;
-CONSTEXPR const float GenericMath::R_HALF_PI;
-CONSTEXPR const float GenericMath::E;
-CONSTEXPR const float GenericMath::R_LN_2;
-CONSTEXPR const float GenericMath::RAD_TO_DEG_CONV; // 180.0f/PI;
-CONSTEXPR const float GenericMath::DEG_TO_RAD_CONV; // PI/180.0f;
+CONSTEXPR const float GenericMath::PI = 3.1415926535897932f;
+CONSTEXPR const float GenericMath::TWO_PI = 6.28318530717959f;
+CONSTEXPR const float GenericMath::HALF_PI = 1.57079632679f;
+CONSTEXPR const float GenericMath::R_PI = 0.31830988618f;
+CONSTEXPR const float GenericMath::R_TWO_PI = 0.159154943091895f;
+CONSTEXPR const float GenericMath::R_HALF_PI = 0.636619772367581f;
+
+CONSTEXPR const float GenericMath::E = 2.71828182845904523536f;
+CONSTEXPR const float GenericMath::R_LN_2 = 1.44269504088896f;
+CONSTEXPR const float GenericMath::RAD_TO_DEG_CONV = 57.2957795130823f; // 180.0f/PI;
+CONSTEXPR const float GenericMath::DEG_TO_RAD_CONV = 0.0174532925199433f; // PI/180.0f;

--- a/src/platform/generic/genericMath.cpp
+++ b/src/platform/generic/genericMath.cpp
@@ -1,13 +1,13 @@
 #include "genericMath.hpp"
 
-CONSTEXPR const float GenericMath::PI = 3.1415926535897932f;
-CONSTEXPR const float GenericMath::TWO_PI = 6.28318530717959f;
-CONSTEXPR const float GenericMath::HALF_PI = 1.57079632679f;
-CONSTEXPR const float GenericMath::R_PI = 0.31830988618f;
-CONSTEXPR const float GenericMath::R_TWO_PI = 0.159154943091895f;
-CONSTEXPR const float GenericMath::R_HALF_PI = 0.636619772367581f;
+const float GenericMath::PI = 3.1415926535897932f;
+const float GenericMath::TWO_PI = 6.28318530717959f;
+const float GenericMath::HALF_PI = 1.57079632679f;
+const float GenericMath::R_PI = 0.31830988618f;
+const float GenericMath::R_TWO_PI = 0.159154943091895f;
+const float GenericMath::R_HALF_PI = 0.636619772367581f;
 
-CONSTEXPR const float GenericMath::E = 2.71828182845904523536f;
-CONSTEXPR const float GenericMath::R_LN_2 = 1.44269504088896f;
-CONSTEXPR const float GenericMath::RAD_TO_DEG_CONV = 57.2957795130823f; // 180.0f/PI;
-CONSTEXPR const float GenericMath::DEG_TO_RAD_CONV = 0.0174532925199433f; // PI/180.0f;
+const float GenericMath::E = 2.71828182845904523536f;
+const float GenericMath::R_LN_2 = 1.44269504088896f;
+const float GenericMath::RAD_TO_DEG_CONV = 57.2957795130823f; // 180.0f/PI;
+const float GenericMath::DEG_TO_RAD_CONV = 0.0174532925199433f; // PI/180.0f;

--- a/src/platform/generic/genericMath.hpp
+++ b/src/platform/generic/genericMath.hpp
@@ -16,17 +16,17 @@
  */
 struct GenericMath
 {
-	static CONSTEXPR const float PI;
-	static CONSTEXPR const float TWO_PI;
-	static CONSTEXPR const float HALF_PI;
-	static CONSTEXPR const float R_PI;
-	static CONSTEXPR const float R_TWO_PI;
-	static CONSTEXPR const float R_HALF_PI;
+	static const float PI;
+	static const float TWO_PI;
+	static const float HALF_PI;
+	static const float R_PI;
+	static const float R_TWO_PI;
+	static const float R_HALF_PI;
 
-	static CONSTEXPR const float E;
-	static CONSTEXPR const float R_LN_2;
-	static CONSTEXPR const float RAD_TO_DEG_CONV; // 180.0f/PI;
-	static CONSTEXPR const float DEG_TO_RAD_CONV; // PI/180.0f;
+	static const float E;
+	static const float R_LN_2;
+	static const float RAD_TO_DEG_CONV; // 180.0f/PI;
+	static const float DEG_TO_RAD_CONV; // PI/180.0f;
 
 	static CONSTEXPR FORCEINLINE int32 truncToInt(float val)
 	{

--- a/src/platform/generic/genericMath.hpp
+++ b/src/platform/generic/genericMath.hpp
@@ -16,17 +16,17 @@
  */
 struct GenericMath
 {
-	static CONSTEXPR const float PI = 3.1415926535897932f;
-	static CONSTEXPR const float TWO_PI = 6.28318530717959f;
-	static CONSTEXPR const float HALF_PI = 1.57079632679f;
-	static CONSTEXPR const float R_PI = 0.31830988618f;
-	static CONSTEXPR const float R_TWO_PI = 0.159154943091895f;
-	static CONSTEXPR const float R_HALF_PI = 0.636619772367581f;
+	static CONSTEXPR const float PI;
+	static CONSTEXPR const float TWO_PI;
+	static CONSTEXPR const float HALF_PI;
+	static CONSTEXPR const float R_PI;
+	static CONSTEXPR const float R_TWO_PI;
+	static CONSTEXPR const float R_HALF_PI;
 
-	static CONSTEXPR const float E = 2.71828182845904523536f;
-	static CONSTEXPR const float R_LN_2 = 1.44269504088896f;
-	static CONSTEXPR const float RAD_TO_DEG_CONV = 57.2957795130823f; // 180.0f/PI;
-	static CONSTEXPR const float DEG_TO_RAD_CONV = 0.0174532925199433f; // PI/180.0f;
+	static CONSTEXPR const float E;
+	static CONSTEXPR const float R_LN_2;
+	static CONSTEXPR const float RAD_TO_DEG_CONV; // 180.0f/PI;
+	static CONSTEXPR const float DEG_TO_RAD_CONV; // PI/180.0f;
 
 	static CONSTEXPR FORCEINLINE int32 truncToInt(float val)
 	{

--- a/src/platform/generic/genericMemory.hpp
+++ b/src/platform/generic/genericMemory.hpp
@@ -40,11 +40,13 @@ struct GenericMemory
 
 	static void memswap(void* a, void* b, uintptr size)
 	{
-		char temp_data[size];
+		char* temp_data = new char[size];
 		void* temp = (void*)&temp_data;
 		GenericMemory::memcpy(temp, a, size);
 		GenericMemory::memcpy(a, b, size);
 		GenericMemory::memcpy(b, temp, size);
+
+		delete[] temp_data;
 	}
 
 	template<typename T>

--- a/src/platform/sse/sseVecmath.hpp
+++ b/src/platform/sse/sseVecmath.hpp
@@ -261,17 +261,16 @@ public:
 		return SSEVector::load1f((*this)[index]);
 	}
 
-	FORCEINLINE SSEVector swizzle(const uint32 x, const uint32 y, const uint32 z, const uint32 w) const
-	{
-		assertCheck(x <= 3);
-		assertCheck(y <= 3);
-		assertCheck(z <= 3);
-		assertCheck(w <= 3);
-		SSEVector vec;
-		vec.data = _mm_shuffle_ps(data, data,
-				SSEVector_SHUFFLEMASK(x, y, z, w));
-		return vec;
-	}
+	//FORCEINLINE SSEVector swizzle(const uint32 x, const uint32 y, const uint32 z, const uint32 w) const
+	//{
+	//	assertCheck(x <= 3);
+	//	assertCheck(y <= 3);
+	//	assertCheck(z <= 3);
+	//	assertCheck(w <= 3);
+	//	SSEVector vec;
+	//	vec.data = _mm_shuffle_ps(data, data, ((x) | ((y) << 2) | ((z) << 4) | ((w) << 6)));
+	//	return vec;
+	//}
 	
 	FORCEINLINE SSEVector abs() const
 	{

--- a/src/rendering/indexedModel.cpp
+++ b/src/rendering/indexedModel.cpp
@@ -77,7 +77,8 @@ uint32 IndexedModel::createVertexArray(RenderDevice& device,
 {
 	Array<const float*> vertexDataArray;
 	for(uint32 i = 0; i < elementSizes.size(); i++) {
-		vertexDataArray.push_back(&(elements[i][0]));
+		if (elements[i].size() > 0)
+			vertexDataArray.push_back(&(elements[i][0]));
 	}
 
 	const float** vertexData = &vertexDataArray[0];


### PR DESCRIPTION
Hello Benny,

I have tried to compile and run this new project on my windows system and have encountered a few problems, so I figured I might as well volunteer to solve the problems, so I went ahead and did that, and here is the detailed explanation of every change in this contribution:

- I had a problem related to the default directory structure of SDL2: When I installed SDL2 on my systemn, the default structure  was something like `%SDL2_ROOT_DIR%/include/*.h`. I need to move everything under `%SDL2_ROOT_DIR%/include/SDL2/*.h` for everything to work smoothly. I thought it may help someone so I went ahead and added a warning about that in the README.

- I moved the initialisation of static const floats in `genericMath.cpp` file rather than having them in the hpp file, which would not let me compile. (https://stackoverflow.com/a/2454082/3909725)

- Under `indexedModel.cpp` in the `createVertexArray` method, some element of the elements Array was empty, which made the program crash at runtime. I added an if statement to eliminate those empty elements. I don't know if that was the right solution to the problem, but hey, at least it made it work.

- `__attribute__ ((always_inline))` does not work and results in horrible unreadable compilation errors under **MSVC**, I added a small test to only set FORCEINLINE to this macro on GNU based systems, and just default to simple inline on all other cases.

- I could not get the program to compile with the "normal" `main` prototype on my windows machine; seemed like the only way to get it to work was by replacing `main` with `wmain`. I added a snippet of preprocessor code to choose the proper declaration at compile time. I know it's kind of a hack, but I couldn't find a better way to get it to work, and at least it's generic.

- In genericMemory.hpp, the memswap function used  to declare a  char `temp_data[size]` which would not compile on my system because the `size` argument is dynamic and only known at runtime. I replaced the `temp_data` array with a dynamic array which is destroyed at the end of the function call.

- The swizzle method in `sseVecmath.hpp` would not compile on my system, with the compiler raising a "C20557: expected constant expression" error. Since the method is not used for the moment and since I could not figure out the reason for this error, **I just commented it for the moment, hoping that you would know how to solve the issue :)**

With these few tweaks, I was able to run the project using MSVC and Visual Studio Community 15 2017.
I hope I have not broken anything for the other environments/platforms, and I hope you'll be able to integrate my fixes to the project.

Please feel free to tell me if anything looks off or needs to be changed around a bit before integrating to the project.

Sincerely,
