### PR TITLE
Update CMakeLists.txt to link math library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,5 +102,6 @@ target_link_libraries( CGFX5
 	${GLEW_LIBRARIES}
 	${SDL2_LIBRARIES}
 	${ASSIMP_LIBRARIES}
+	m
 )
 


### PR DESCRIPTION
Required for this to build on NixOS (and most likely some other distros)

Without this change, the linker will return an error saying that `pow` and `log` can't be found.