### PR TITLE
Source group source files in Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,10 @@ add_definitions( -O2 )
 endif ( CMAKE_BUILD_TYPE STREQUAL "Release" )
 
 # Lets LOAD app our headers!
-file(GLOB_RECURSE HDRS ${CGFX5_SOURCE_DIR}/src/*.h)
+file(GLOB_RECURSE HDRS
+	${CGFX5_SOURCE_DIR}/src/*.h
+	${CGFX5_SOURCE_DIR}/src/*.hpp
+)
 
 # Lets LOAD app our sources!
 file(GLOB_RECURSE SRCS
@@ -104,3 +107,13 @@ target_link_libraries( CGFX5
 	${ASSIMP_LIBRARIES}
 )
 
+
+#Create virtual folders to make it look nicer in VS
+if(MSVC_IDE)
+	foreach(source IN LISTS SRCS HDRS)
+		get_filename_component(source_path "${source}" PATH)
+		string(REPLACE "${CGFX5_SOURCE_DIR}" "" relative_source_path "${source_path}")
+		string(REPLACE "/" "\\" source_path_msvc "${relative_source_path}")
+		source_group("${source_path_msvc}" FILES "${source}")
+	endforeach()
+endif()


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/12570757/40328401-873b2eb8-5d46-11e8-9c61-e46f8ec2fa6f.gif)

After:
![after](https://user-images.githubusercontent.com/12570757/40328304-33cda0c6-5d46-11e8-94ad-dae869364151.png)

The only problem is that visual studio places new files in the build directory by default :/